### PR TITLE
Stop pubnub from crashing EventMachine through unsafe use of threads.

### DIFF
--- a/3.3/lib/pubnub.rb
+++ b/3.3/lib/pubnub.rb
@@ -282,7 +282,7 @@ class Pubnub
 
   def _request(request, is_reactor_running = false)
     request.format_url!
-    Thread.new{
+    EM.schedule {
       begin
 
         operation_timeout = %w(subscribe presence).include?(request.operation) ? TIMEOUT_SUBSCRIBE : TIMEOUT_NON_SUBSCRIBE
@@ -323,7 +323,7 @@ class Pubnub
       rescue EventMachine::ConnectionError, RuntimeError => e # RuntimeError for catching "EventMachine not initialized"
         error_message = "Network Error: #{e.message}"
         puts(error_message)
-        return [0, error_message]
+        [0, error_message]
       end
     }
   end


### PR DESCRIPTION
**Problem**: Under moderate load(~50 publishes in one go) pubnub caused EventMachine to crash and drop all the following publishes on the floor.  
**Reason**: EM is not threadsafe, by design. Everything is supposed to be done on the single reactor thread, using EM.defer/EM.schedule if necessary. Worker threads & the reactor pattern are sort of two opposing paradigms and shouldn't be mixed.  
**Solution**: dont use threads inside a reactor.
