### PR TITLE
Allow to pass custom logger

### DIFF
--- a/3.3/lib/pubnub.rb
+++ b/3.3/lib/pubnub.rb
@@ -38,9 +38,6 @@ class Pubnub
   TIMEOUT_SUBSCRIBE = 310
   TIMEOUT_NON_SUBSCRIBE = 5
 
-  PUBNUB_LOGGER = Logger.new("#{Dir.tmpdir}/pubnubError.log", 10, 10000000)
-  PUBNUB_LOGGER.level = Logger::DEBUG
-
   class PresenceError < RuntimeError;
   end
   class PublishError < RuntimeError;
@@ -73,6 +70,7 @@ class Pubnub
       @secret_key = options_hash[:secret_key].blank? ? nil : options_hash[:secret_key].to_s
       @cipher_key = options_hash[:cipher_key].blank? ? nil : options_hash[:cipher_key].to_s
       @ssl = options_hash[:ssl].blank? ? false : true
+      @logger = options_hash[:logger]
 
     else
       raise(InitError, "Initialize with either a hash of options, or exactly 5 named parameters.")
@@ -278,6 +276,10 @@ class Pubnub
     end
   end
 
+  def logger
+    @logger ||= initDefaultLogger
+  end
+
   private
 
   def _request(request, is_reactor_running = false)
@@ -378,9 +380,9 @@ class Pubnub
   end
 
   def logError(errMsg, url)
-    PUBNUB_LOGGER.debug("url: #{url}")
-    PUBNUB_LOGGER.debug("#{errMsg}")
-    PUBNUB_LOGGER.debug("")
+    logger.debug("url: #{url}")
+    logger.debug("#{errMsg}")
+    logger.debug("")
   end
 
   def retryRequest(is_reactor_running, req, request, delay)
@@ -395,11 +397,17 @@ class Pubnub
       request.set_error(true)
       request.callback.call(error_msg)
 
-      PUBNUB_LOGGER.debug(error_msg)
+      logger.debug(error_msg)
 
       EM.stop unless is_reactor_running
     end
 
+  end
+
+  def initDefaultLogger
+    logger = Logger.new("#{Dir.tmpdir}/pubnubError.log", 10, 10000000)
+    logger.level = Logger::DEBUG
+    logger
   end
 
 end

--- a/3.3/spec/lib/pubnub_spec.rb
+++ b/3.3/spec/lib/pubnub_spec.rb
@@ -83,6 +83,7 @@ describe Pubnub do
       @cipher_key = "demo_cipher_key"
       @ssl_enabled = false
       @channel = "pn_test"
+      @logger  = Object.new
     end
 
     context "when initialized" do
@@ -124,9 +125,14 @@ describe Pubnub do
                            :subscribe_key => @subscribe_key,
                            :secret_key => @secret_key,
                            :cipher_key => @cipher_key,
-                           :ssl => @ssl_enabled)
+                           :ssl => @ssl_enabled,
+                           :logger => @logger)
         end
         it_behaves_like "successful initialization"
+
+        it "uses passed logger" do
+          @pn.logger.should == @logger
+        end
       end
 
       context "when the hash key is named" do
@@ -136,9 +142,14 @@ describe Pubnub do
                            "subscribe_key" => @subscribe_key,
                            "secret_key" => @secret_key,
                            "cipher_key" => @cipher_key,
-                           "ssl" => @ssl_enabled)
+                           "ssl" => @ssl_enabled,
+                           "logger" => @logger)
         end
         it_behaves_like "successful initialization"
+
+        it "uses passed logger" do
+          @pn.logger.should == @logger
+        end
 
       end
 
@@ -654,6 +665,25 @@ describe Pubnub do
         @pn.here_now(:channel => :hello_world, :callback => @my_callback)
       end
 
+    end
+
+  end
+
+  describe "logger" do
+
+    before do
+      @sub_key = "demo"
+    end
+
+    it "defaults to Ruby Logger" do
+      pn = Pubnub.new(:subscribe_key => @sub_key)
+      pn.logger.should be_kind_of(::Logger)
+    end
+
+    it "accepts custom logger" do
+      logger = Object.new
+      pn = Pubnub.new(:subscribe_key => @sub_key, :logger => logger)
+      pn.logger.should == logger
     end
 
   end

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ pubnub = Pubnub.new(
     :subscribe_key => 'demo', # required
     :secret_key    => nil,    # optional, if used, message signing is enabled
     :cipher_key    => nil,    # optional, if used, encryption is enabled
-    :ssl           => nil     # true or default is false
+    :ssl           => nil,    # true or default is false
+    :logger        => nil     # optional, if used, you can pass your own logger, eg. Rails.logger
 )
 ```
 


### PR DESCRIPTION
Current logger always logs to /tmp/pubnubError.log.
This patch allows to pass own logger, eg. Rails.logger or Syslog.

Custom logger can be passed in initializer through options hash:

``` ruby
Pubnub.new(:subscribe_key => '...', :logger => Rails.logger)
```

If custom logger is not given it uses default logger.
