### PR TITLE
remove yajl-ruby for jruby compatibility

### DIFF
--- a/3.3/pubnub.gemspec
+++ b/3.3/pubnub.gemspec
@@ -27,8 +27,9 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine"
   s.add_dependency "em-http-request"
   s.add_dependency "uuid", "~> 2.3.5"
-  s.add_dependency "yajl-ruby"
   s.add_dependency "json"
+  
+  s.add_development_dependency "yajl-ruby" # not compatible with JRuby
 
 
 end


### PR DESCRIPTION
due yajl-ruby's C-extensions the gem can not be installed on JRuby
it would be great if yajl was optional (detected at runtime) ...