### PR TITLE
The Pubnub module should have the VERSION constant

### DIFF
--- a/lib/pubnub/configuration.rb
+++ b/lib/pubnub/configuration.rb
@@ -9,7 +9,7 @@ module Pubnub
     DEFAULT_PATH               = '/'
     DEFAULT_PARAMS             = {}
     DEFAULT_HEADERS            = {}
-    DEFAULT_USER_AGENT         = "Pubnub Ruby #{PUBNUB_VERSION}"
+    DEFAULT_USER_AGENT         = "Pubnub Ruby #{VERSION}"
     DEFAULT_SSL_SET            = false
     DEFAULT_TIMEOUT            = 5
     DEFAULT_ENCODING           = nil

--- a/lib/pubnub/version.rb
+++ b/lib/pubnub/version.rb
@@ -1,0 +1,3 @@
+module Pubnub
+  VERSION = "3.4"
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,1 +1,0 @@
-PUBNUB_VERSION = '3.4'


### PR DESCRIPTION
This fixes issue: https://github.com/pubnub/ruby/issues/17
