### PR TITLE
When heartbeat is set, it needs to be supplied as a parameter - at least...

### DIFF
--- a/lib/pubnub/event.rb
+++ b/lib/pubnub/event.rb
@@ -217,7 +217,8 @@ module Pubnub
 
       empty_if_blank = {
           :auth => @auth_key,
-          :uuid => app.env[:uuid]
+          :uuid => app.env[:uuid],
+          :heartbeat => app.env[:heartbeat]
       }
 
       empty_if_blank.delete_if {|k, v| v.blank? }


### PR DESCRIPTION
Presence heartbeat timeouts don't appear to work. When comparing log output from the Ruby gem, it appears that Heartbeats weren't supplying the heartbeat parameter. The Javascript sdk does work and does supply the heartbeat parameter.

This pull request sets the 'heartbeat' param if it is set for all events. Not clear to me if this is the most correct solution, but it does work.
