### PR TITLE
Colons in channel names are incorrectly encoded

### DIFF
--- a/lib/pubnub/event.rb
+++ b/lib/pubnub/event.rb
@@ -202,7 +202,9 @@ module Pubnub
 
     def uri(app)
       $logger.debug('Pubnub'){"#{self.class}#uri #{[origin(app), path(app), '?', params_hash_to_url_params(parameters(app))].join}"}
-      URI [origin(app), path(app), '?', params_hash_to_url_params(parameters(app))].join
+      uri = URI [origin(app), path(app), '?', params_hash_to_url_params(parameters(app))].join
+      puts uri.to_s
+      uri
     end
 
     def origin(app)

--- a/spec/lib/encoder_spec.rb
+++ b/spec/lib/encoder_spec.rb
@@ -46,6 +46,12 @@ describe 'Pubnub::Formatter' do
       encoded = @formater.encode_channel('Some Channel with+special+chars=[];!@#$%^&*()')
       encoded.should eq 'Some%20Channel%20with%2Bspecial%2Bchars%3D%5B%5D%3B%21%40%23%24%25%5E%26*%28%29'
     end
+
+    it 'encodes channel with colon' do
+      encoded = @formater.encode_channel('test1:test2')
+      encoded.should eq 'test1%3Atest2'
+    end
+
   end
 
 end

--- a/spec/lib/subscribe_event.rb
+++ b/spec/lib/subscribe_event.rb
@@ -13,4 +13,11 @@ describe 'Pubnub::SubscribeEvent' do
       end
     end
   end
+
+
+  it 'should encode the URI correctly' do
+    @pn = Pubnub.new(:subscribe_key => 'demo-36', :publish_key => 'demo-36')
+    @pn.subscribe(:http_sync => true, :channel => 'demo:demo'){|e| }
+  end
+
 end


### PR DESCRIPTION
We have hit an issue whereby colons in channel names are incorrectly encoded and thus the authorisation with the PubNub backend fails.

This commit does not really offer a solution but provides a clearly understandable test case of our problem. I don't intend this to be merged so forgive me the sloppy `puts`.

To see the problem switch to this branch and run `rspec spec/lib/subscribe_event.rb`. The name of the channel is "demo:demo" which is encoded as `demo%253Ademo`. It seems that the colon is encoded twice because the correct encoding would be `demo%3Ademo`.

This is causing our customers to not be able to use this Ruby client. It'd be great if you could provide a fix.

If you have any further questions, please shoot.

Thanks,
Leonard
