### PR TITLE
Fix typo in the publish event's log output

### DIFF
--- a/lib/pubnub/events/publish.rb
+++ b/lib/pubnub/events/publish.rb
@@ -13,7 +13,7 @@ module Pubnub
       @allow_multiple_channels = false
 
       $logger.info('Pubnub'){ "Bytesize: #{uri(app).to_s.bytesize}" }
-      $logger.info('Pubnub'){ "Lenght:   #{uri(app).to_s.length}" }
+      $logger.info('Pubnub'){ "Length:   #{uri(app).to_s.length}" }
 
       # raise ArgumentError.new(:object => self, :message => ':message argument is too big, encoded uri would excess 32k size limit') if uri(app).to_s.bytesize > 32000
     end


### PR DESCRIPTION
Just a small fix. :+1: 