### PR TITLE
Fixed Digest::Digest is deprecated; use Digest

### DIFF
--- a/lib/pubnub/pam.rb
+++ b/lib/pubnub/pam.rb
@@ -11,7 +11,7 @@ module Pubnub
     def signature(app)
       channel = @original_channel.first
       message = "#{@subscribe_key}\n#{@publish_key}\n#{@event}\n#{variables_for_signature(app)}"
-      Base64.urlsafe_encode64(OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha256'), @secret_key.to_s, message)).strip
+      Base64.urlsafe_encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), @secret_key.to_s, message)).strip
     end
 
     def parameters(app, signature = false)


### PR DESCRIPTION
#### This fixes the following deprecation warning:

```Digest::Digest is deprecated; use Digest```