### PR TITLE
Fix paged_history

### DIFF
--- a/lib/pubnub/client.rb
+++ b/lib/pubnub/client.rb
@@ -57,7 +57,7 @@ module Pubnub
           page.times do
             envelopes << self.history(:channel => channel, :http_sync => true, :count => limit, :start => current_start_tt, :end => end_tt)
             envelopes.flatten!
-            current_start_tt = envelopes.last.history_end.to_i - 1
+            current_start_tt = envelopes.last.history_end.to_i + 1
           end
 
           envelopes.flatten!


### PR DESCRIPTION
Fixes undefined variable within paged_history. Fixes flaw in logic causing the same set of envelopes to be fetched over and over again. Fixes issue in which only the last page would be returned.