### PR TITLE
Problem: If a rescue block succeeds, then a false is returned in spite…

### DIFF
--- a/lib/pubnub/event.rb
+++ b/lib/pubnub/event.rb
@@ -84,8 +84,8 @@ module Pubnub
           Pubnub.logger.error(:pubnub){"Aborting #{self.class} event due to network errors and reaching max retries"}
           app.env[:subscribe_railgun].cancel if app.env[:subscribe_railgun]
           app.env[:subscribe_railgun] = nil
+          false
         end
-        false
       end
     end
 


### PR DESCRIPTION
… of the success

Fix: Move the false return value into the non-success portiion of the rescue block
     so false is returned only on failure and the start_event result is returned