### PR TITLE
Gem simplecov at 0.12.0, which supports Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ bundler_args: --without development
 
 script: bundle exec rspec
 
-rvm:
- - 2.3.1
- - 2.2.5
- - 2.1.9
- - jruby-9.1.5.0
-
 matrix:
   include:
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,28 @@
 sudo: false
-
+language: ruby
 addons:
-    code_climate:
-        repo_token: 48739096f72763cbed9bd407efd2ed33151ce5663fb3181455128f06d6123ef3
+  code_climate:
+    repo_token: 48739096f72763cbed9bd407efd2ed33151ce5663fb3181455128f06d6123ef3
 
 before_install:
   - gem update bundler
 
-language: ruby
+bundler_args: --without development
+
+script: bundle exec rspec
+
 rvm:
  - 2.3.1
  - 2.2.5
  - 2.1.9
- # - 2.0.0
- - jruby-9.0.5.0
+ - jruby-9.1.5.0
 
-env:
- - JRUBY_OPTS="--server -J-Xms1500m -J-Xmx1500m -J-XX:+UseConcMarkSweepGC -J-XX:-UseGCOverheadLimit -J-XX:+CMSClassUnloadingEnabled"
+matrix:
+  include:
+    - rvm: 2.3.1
+    - rvm: 2.2.5
+    - rvm: 2.1.9
+    - rvm: jruby-9.1.5.0
+      env: JRUBY_OPTS="--server -J-Xms1500m -J-Xmx1500m -J-XX:+UseConcMarkSweepGC -J-XX:-UseGCOverheadLimit -J-XX:+CMSClassUnloadingEnabled"
+      jdk: oraclejdk7
 
-bundler_args: --without development
-
-script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :test do
   gem 'rubocop'
-  gem 'simplecov', require: false
+  gem 'simplecov', '>= 0.12', require: false
   gem 'codecov', require: false
   gem 'rspec'
   gem 'rspec-wait'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    pubnub (4.0.7)
+    pubnub (4.0.8)
       celluloid (~> 0.17)
       dry-validation (~> 0.10)
       httpclient (~> 2.8)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
 
 GEM
   remote: https://rubygems.org/
@@ -63,7 +63,7 @@ GEM
       dry-equalizer (~> 0.2)
       dry-logic (~> 0.4, >= 0.4.0)
       inflecto (~> 0.0.0, >= 0.0.2)
-    dry-validation (0.10.1)
+    dry-validation (0.10.3)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
       dry-container (~> 0.2, >= 0.2.8)
@@ -76,8 +76,8 @@ GEM
     hitimes (1.2.4-java)
     httpclient (2.8.2.4)
     inflecto (0.0.2)
-    json (1.8.3)
-    json (1.8.3-java)
+    json (2.0.2)
+    json (2.0.2-java)
     method_source (0.8.2)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
@@ -116,9 +116,9 @@ GEM
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
-    simplecov (0.11.1)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
@@ -146,7 +146,7 @@ DEPENDENCIES
   rspec
   rspec-wait
   rubocop
-  simplecov
+  simplecov (>= 0.12)
   vcr
   webmock
 

--- a/pubnub.gemspec
+++ b/pubnub.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths   = ['lib']
 
   spec.add_dependency 'celluloid',           '~> 0.17'
-  spec.add_dependency 'json',                '~> 1.8'
+  spec.add_dependency 'json',                '>= 1.8', '< 3'
   spec.add_dependency 'httpclient',          '~> 2.8'
   spec.add_dependency 'dry-validation',      '~> 0.10'
   spec.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
Hi! Here's a PR to ease the `'~> 1.8'` json requirement. (SimpleCov, which is also a dependency, had already taken this step.)

---

Also took the gangster step of replacing the quite old jruby-9.0.5.0 with JRuby 9.1.5.0, which is latest stable. In doing that, I localized the ENV variables and chose a JDK for it.
