### PR TITLE
Improve error handling for PAM

### DIFF
--- a/spec/lib/events/grant_spec.rb
+++ b/spec/lib/events/grant_spec.rb
@@ -45,6 +45,19 @@ describe Pubnub::Grant do
         expect(envelope.result).to satisfies_schema Pubnub::Schemas::Envelope::ResultSchema
       end
     end
+
+    it 'forms valid ErrorEnvelope on timeout error' do
+      HTTPClient.any_instance.stub(get: HTTPClient::ReceiveTimeoutError.new)
+
+      envelope = @pubnub.grant(
+          channel: :demo
+      ).value
+
+      expect(envelope.is_a?(Pubnub::ErrorEnvelope)).to eq true
+      expect(envelope.status[:code]).to eq 408
+      expect(envelope.status[:category]).to eq Pubnub::Constants::STATUS_TIMEOUT
+      expect(envelope.status).to satisfies_schema Pubnub::Schemas::Envelope::StatusSchema
+    end
   end
 
 end


### PR DESCRIPTION
I've seen many "NoMethodError: undefined method `code' for #<HTTPClient::ReceiveTimeoutError: execution expired>" on our production env, this PR fixes it.

# Env

- ruby 2.2.3
- pubnub-ruby v4.0.16
- PAM enabled

# Question

I've also seen few errors like bellow from `Pubnub::PAM#error_envelope`. `Pubnub::PAM#error_envelope` and `Pubnub::Event#error_envelope` should care these errors?

- undefined method `body' for #<SocketError:0x007f0bb1efffb0>
- undefined method `body' for #<HTTPClient::SendTimeoutError: execution expired>
- undefined method `body' for #<HTTPClient::ConnectTimeoutError: execution expired>

# Stacktrace

```
NoMethodError: undefined method `code' for #<HTTPClient::ReceiveTimeoutError: execution expired>
  from pubnub/pam.rb:92:in `error_envelope'
  from pubnub/event.rb:147:in `format_envelopes'
  from pubnub/event.rb:142:in `handle'
  from pubnub/event.rb:33:in `fire'
  from celluloid/calls.rb:28:in `public_send'
  from celluloid/calls.rb:28:in `dispatch'
  from celluloid/call/sync.rb:16:in `dispatch'
  from celluloid/cell.rb:50:in `block in dispatch'
  from celluloid/cell.rb:76:in `block in task'
  from celluloid/actor.rb:339:in `block in task'
  from celluloid/task.rb:44:in `block in initialize'
  from celluloid/task/fibered.rb:14:in `block in create'
  from (celluloid):0:in `remote procedure call'
  from celluloid/call/sync.rb:45:in `value'
  from celluloid/proxy/sync.rb:22:in `method_missing'
  from pubnub/client/events.rb:18:in `block (2 levels) in <module:Events>'
  from app/models/stream/grant_requester.rb:66:in `grant_envelope'
  from app/models/stream/grant_requester.rb:57:in `grant'
  from app/models/stream/grant_requester.rb:44:in `grant_for_onetime'
  from app/models/stream/grant_requester.rb:21:in `grant_for_onetime'
  from app/controllers/reception_controller.rb:36:in `stream'
  from action_controller/metal/implicit_render.rb:4:in `send_action'
  from abstract_controller/base.rb:198:in `process_action'
  from action_controller/metal/rendering.rb:10:in `process_action'
  from abstract_controller/callbacks.rb:20:in `block in process_action'
  from active_support/callbacks.rb:117:in `call'
  from active_support/callbacks.rb:117:in `call'
  from active_support/callbacks.rb:555:in `block (2 levels) in compile'
  from active_support/callbacks.rb:505:in `call'
  from active_support/callbacks.rb:505:in `call'
  from active_support/callbacks.rb:92:in `__run_callbacks__'
  from active_support/callbacks.rb:778:in `_run_process_action_callbacks'
  from active_support/callbacks.rb:81:in `run_callbacks'
  from abstract_controller/callbacks.rb:19:in `process_action'
  from action_controller/metal/rescue.rb:29:in `process_action'
  from action_controller/metal/instrumentation.rb:32:in `block in process_action'
  from active_support/notifications.rb:164:in `block in instrument'
  from active_support/notifications/instrumenter.rb:20:in `instrument'
  from active_support/notifications.rb:164:in `instrument'
  from action_controller/metal/instrumentation.rb:30:in `process_action'
  from action_controller/metal/params_wrapper.rb:250:in `process_action'
  from active_record/railties/controller_runtime.rb:18:in `process_action'
  from abstract_controller/base.rb:137:in `process'
  from action_view/rendering.rb:30:in `process'
  from action_controller/metal.rb:196:in `dispatch'
  from action_controller/metal/rack_delegation.rb:13:in `dispatch'
  from action_controller/metal.rb:237:in `block in action'
  from action_dispatch/routing/route_set.rb:74:in `call'
  from action_dispatch/routing/route_set.rb:74:in `dispatch'
  from action_dispatch/routing/route_set.rb:43:in `serve'
  from action_dispatch/journey/router.rb:43:in `block in serve'
  from action_dispatch/journey/router.rb:30:in `each'
  from action_dispatch/journey/router.rb:30:in `serve'
  from action_dispatch/routing/route_set.rb:817:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from new_relic/rack/agent_hooks.rb:30:in `traced_call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from new_relic/rack/browser_monitoring.rb:32:in `traced_call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from exception_notification/rack.rb:32:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rack/etag.rb:24:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rack/conditionalget.rb:38:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rack/user_agent.rb:16:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rack/head.rb:13:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/params_parser.rb:27:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from jpmobile/rack/mobile_carrier.rb:12:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/flash.rb:260:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rack/session/abstract/id.rb:225:in `context'
  from rack/session/abstract/id.rb:220:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/cookies.rb:560:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from active_record/query_cache.rb:36:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/callbacks.rb:29:in `block in call'
  from active_support/callbacks.rb:88:in `__run_callbacks__'
  from active_support/callbacks.rb:778:in `_run_call_callbacks'
  from active_support/callbacks.rb:81:in `run_callbacks'
  from action_dispatch/middleware/callbacks.rb:27:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/remote_ip.rb:78:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/show_exceptions.rb:30:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rails/rack/logger.rb:38:in `call_app'
  from rails/rack/logger.rb:20:in `block in call'
  from active_support/tagged_logging.rb:68:in `block in tagged'
  from active_support/tagged_logging.rb:26:in `tagged'
  from active_support/tagged_logging.rb:68:in `tagged'
  from rails/rack/logger.rb:20:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from request_store/middleware.rb:9:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/request_id.rb:21:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rack/methodoverride.rb:22:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rack/runtime.rb:18:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rack/sendfile.rb:113:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from action_dispatch/middleware/ssl.rb:24:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from raven/integrations/rack.rb:50:in `call'
  from new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  from rails/engine.rb:518:in `call'
  from rails/application.rb:165:in `call'
 ...
```