### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Coverage Status](https://coveralls.io/repos/github/pubnub/ruby/badge.svg?branch=master)](https://coveralls.io/github/pubnub/ruby?branch=master)
 [![Build Status](https://travis-ci.org/pubnub/ruby.svg?branch=master)](https://travis-ci.org/pubnub/ruby)
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/PubNub/functions?utm_source=PubnubGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 # Please direct all Support Questions and Concerns to Support@PubNub.com
 


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out PubNub API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!