### PR TITLE
Update gemspec to require httpclient >= 2.8.3

### DIFF
--- a/pubnub.gemspec
+++ b/pubnub.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'celluloid',           '~> 0.17'
   spec.add_dependency 'json',                '>= 1.8', '< 3'
-  spec.add_dependency 'httpclient',          '~> 2.8'
+  spec.add_dependency 'httpclient',          '~> 2.8', '>= 2.8.3'
   spec.add_dependency 'dry-validation',      '~> 0.10'
   spec.add_development_dependency 'bundler', '~> 1.7'
 end


### PR DESCRIPTION
Since this library uses the `HTTPClient#tcp_keepalive=` method, update the gemspec to require the version of httpclient where that method was added.

Relevant `httpclient` changelog:
https://github.com/nahi/httpclient/blob/master/CHANGELOG.md#changes-in-283