### PR TITLE
Gracefully handle all http timeout errors

### DIFF
--- a/lib/pubnub/event.rb
+++ b/lib/pubnub/event.rb
@@ -174,7 +174,7 @@ module Pubnub
       when JSON::ParserError
         error_category = Pubnub::Constants::STATUS_NON_JSON_RESPONSE
         code = req_res_objects[:response].code
-      when HTTPClient::ReceiveTimeoutError
+      when HTTPClient::TimeoutError
         error_category = Pubnub::Constants::STATUS_TIMEOUT
         code = 408
       when OpenSSL::SSL::SSLError

--- a/lib/pubnub/event/formatter.rb
+++ b/lib/pubnub/event/formatter.rb
@@ -5,9 +5,7 @@ module Pubnub
     # Module that holds formatters for events
     module EFormatter
       def format_envelopes(response, request)
-        if response.is_a? HTTPClient::ReceiveTimeoutError
-          return error_envelope(nil, response, request: request, response: response)
-        elsif response.is_a? OpenSSL::SSL::SSLError
+        if response.kind_of?(HTTPClient::TimeoutError) || response.is_a?(OpenSSL::SSL::SSLError)
           return error_envelope(nil, response, request: request, response: response)
         else
           parsed_response, error = Formatter.parse_json(response.body)

--- a/lib/pubnub/pam.rb
+++ b/lib/pubnub/pam.rb
@@ -85,7 +85,7 @@ module Pubnub
       when JSON::ParserError
         error_category = Pubnub::Constants::STATUS_NON_JSON_RESPONSE
         code = req_res_objects[:response].code
-      when HTTPClient::ReceiveTimeoutError
+      when HTTPClient::TimeoutError
         error_category = Pubnub::Constants::STATUS_TIMEOUT
         code = 408
       else

--- a/spec/lib/events/grant_spec.rb
+++ b/spec/lib/events/grant_spec.rb
@@ -11,24 +11,26 @@ describe Pubnub::Grant do
 
   context 'given basic parameters' do
     before :each do
-      Pubnub::Grant.any_instance.stub(:current_time).and_return 1463146850
-      Pubnub::Grant.any_instance.stub(:signature).and_return 'udCXAk-z4VaU2JA2LgjVzED2LBZAKsjj86twYJoGPnY='
-
-      @pubnub = Pubnub::Client.new(
-          subscribe_key: 'sub-c-b7fb805a-1777-11e6-be83-0619f8945a4f',
-          publish_key: 'pub-c-b42cec2f-f468-4784-8833-dd2b074538c4',
-          secret_key: 'sec-c-OWIyYmVlYWYtYWMxMS00OTcxLTlhZDAtZDBlYTM4ODE1MWUy',
-          auth_key: 'ruby-test-auth',
-          uuid: 'ruby-test-uuid'
+      allow_any_instance_of(Pubnub::Grant).to receive(:current_time).and_return 1463146850
+      allow_any_instance_of(Pubnub::Grant).to receive(:signature).and_return 'udCXAk-z4VaU2JA2LgjVzED2LBZAKsjj86twYJoGPnY='
+    end
+    let(:pubnub) do
+      Pubnub::Client.new(
+        subscribe_key: 'sub-c-b7fb805a-1777-11e6-be83-0619f8945a4f',
+        publish_key: 'pub-c-b42cec2f-f468-4784-8833-dd2b074538c4',
+        secret_key: 'sec-c-OWIyYmVlYWYtYWMxMS00OTcxLTlhZDAtZDBlYTM4ODE1MWUy',
+        auth_key: 'ruby-test-auth',
+        uuid: 'ruby-test-uuid'
       )
+    end
+    let(:envelope) do
+      pubnub.grant(
+        channel: :demo
+      ).value
     end
 
     it 'works' do
       VCR.use_cassette('lib/events/grant', record: :once) do
-        envelope = @pubnub.grant(
-            channel: :demo
-        ).value
-
         expect(envelope.status).to satisfies_schema Pubnub::Schemas::Envelope::StatusSchema
         expect(envelope.result).to satisfies_schema Pubnub::Schemas::Envelope::ResultSchema
       end
@@ -36,28 +38,25 @@ describe Pubnub::Grant do
 
     it 'forms valid ErrorEnvelope on error' do
       VCR.use_cassette('lib/events/grant-error', record: :once) do
-        envelope = @pubnub.grant(
-            channel: :demo
-        ).value
-
         expect(envelope.is_a?(Pubnub::ErrorEnvelope)).to eq true
         expect(envelope.status).to satisfies_schema Pubnub::Schemas::Envelope::StatusSchema
         expect(envelope.result).to satisfies_schema Pubnub::Schemas::Envelope::ResultSchema
       end
     end
 
-    it 'forms valid ErrorEnvelope on timeout error' do
-      HTTPClient.any_instance.stub(get: HTTPClient::ReceiveTimeoutError.new)
+    [
+      HTTPClient::ConnectTimeoutError,
+      HTTPClient::ReceiveTimeoutError,
+      HTTPClient::SendTimeoutError
+    ].each do |error_class|
+      it "forms valid ErrorEnvelope on #{error_class}" do
+        allow_any_instance_of(HTTPClient).to receive(:get).and_return error_class.new
 
-      envelope = @pubnub.grant(
-          channel: :demo
-      ).value
-
-      expect(envelope.is_a?(Pubnub::ErrorEnvelope)).to eq true
-      expect(envelope.status[:code]).to eq 408
-      expect(envelope.status[:category]).to eq Pubnub::Constants::STATUS_TIMEOUT
-      expect(envelope.status).to satisfies_schema Pubnub::Schemas::Envelope::StatusSchema
+        expect(envelope.is_a?(Pubnub::ErrorEnvelope)).to eq true
+        expect(envelope.status[:code]).to eq 408
+        expect(envelope.status[:category]).to eq Pubnub::Constants::STATUS_TIMEOUT
+        expect(envelope.status).to satisfies_schema Pubnub::Schemas::Envelope::StatusSchema
+      end
     end
   end
-
 end

--- a/spec/lib/events/timeout_handling_spec.rb
+++ b/spec/lib/events/timeout_handling_spec.rb
@@ -8,23 +8,29 @@ describe 'timeout' do
   end
 
   context 'in single event' do
-    before :each do
-      @pubnub = Pubnub::Client.new(
-          subscribe_key: 'sub-c-b7fb805a-1777-11e6-be83-0619f8945a4f',
-          publish_key: 'pub-c-b42cec2f-f468-4784-8833-dd2b074538c4',
-          auth_key: 'ruby-test-auth',
-          uuid: 'ruby-test-uuid'
+    let(:pubnub) do
+      Pubnub::Client.new(
+        subscribe_key: 'sub-c-b7fb805a-1777-11e6-be83-0619f8945a4f',
+        publish_key: 'pub-c-b42cec2f-f468-4784-8833-dd2b074538c4',
+        auth_key: 'ruby-test-auth',
+        uuid: 'ruby-test-uuid'
       )
     end
+    let(:envelope) { pubnub.time.value }
 
-    it 'forms valid ErrorEnvelope on error' do
-      HTTPClient.any_instance.stub(get: HTTPClient::ReceiveTimeoutError.new)
+    [
+      HTTPClient::ConnectTimeoutError,
+      HTTPClient::ReceiveTimeoutError,
+      HTTPClient::SendTimeoutError
+    ].each do |error_class|
+      it "forms valid ErrorEnvelope on #{error_class}" do
+        allow_any_instance_of(HTTPClient).to receive(:get).and_return error_class.new
 
-      envelope = @pubnub.time.value
-      expect(envelope.is_a?(Pubnub::ErrorEnvelope)).to eq true
-      expect(envelope.status[:code]).to eq 408
-      expect(envelope.status[:category]).to eq Pubnub::Constants::STATUS_TIMEOUT
-      expect(envelope.status).to satisfies_schema Pubnub::Schemas::Envelope::StatusSchema
+        expect(envelope.is_a?(Pubnub::ErrorEnvelope)).to eq true
+        expect(envelope.status[:code]).to eq 408
+        expect(envelope.status[:category]).to eq Pubnub::Constants::STATUS_TIMEOUT
+        expect(envelope.status).to satisfies_schema Pubnub::Schemas::Envelope::StatusSchema
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, `HTTPClient::ReceiveTimeoutError` was handled gracefully, but other descendants of `HTTPClient::TimeoutError` were resulting in an error being raised (e.g. `undefined method 'body' for #<HTTPClient::ConnectTimeoutError: execution expired>`). This change ensures that all http timeout errors are handled gracefully.

Additionally, clean up some rspec deprecation warnings in the spec files that were updated as part of this change.