### PR TITLE
Move client timeout options to configurations

### DIFF
--- a/lib/pubnub/client.rb
+++ b/lib/pubnub/client.rb
@@ -328,15 +328,19 @@ module Pubnub
 
       case event_type
       when :subscribe_event
-        hc.receive_timeout = 310
+        hc.connect_timeout = @env[:s_open_timeout]
+        hc.send_timeout = @env[:s_send_timeout]
+        hc.receive_timeout = @env[:s_read_timeout]
         unless @env[:disable_keepalive] || @env[:disable_subscribe_keepalive]
-          hc.keep_alive_timeout = 310
+          hc.keep_alive_timeout = @env[:idle_timeout]
           hc.tcp_keepalive = true
         end
       when :single_event
-        hc.receive_timeout = 5
+        hc.connect_timeout = @env[:open_timeout]
+        hc.send_timeout = @env[:send_timeout]
+        hc.receive_timeout = @env[:read_timeout]
         unless @env[:disable_keepalive] || @env[:disable_non_subscribe_keepalive]
-          hc.keep_alive_timeout = 310
+          hc.keep_alive_timeout = @env[:idle_timeout]
           hc.tcp_keepalive = true
         end
       end

--- a/lib/pubnub/configuration.rb
+++ b/lib/pubnub/configuration.rb
@@ -5,13 +5,16 @@ module Pubnub
     private
 
     def default_values
-      { origin: Pubnub::Constants::DEFAULT_ORIGIN,
+      {
+        origin: Pubnub::Constants::DEFAULT_ORIGIN,
+        idle_timeout: Pubnub::Constants::DEFAULT_IDLE_TIMEOUT,
         open_timeout: Pubnub::Constants::DEFAULT_OPEN_TIMEOUT,
         read_timeout: Pubnub::Constants::DEFAULT_READ_TIMEOUT,
-        idle_timeout: Pubnub::Constants::DEFAULT_IDLE_TIMEOUT,
+        send_timeout: Pubnub::Constants::DEFAULT_SEND_TIMEOUT,
+        s_idle_timeout: Pubnub::Constants::DEFAULT_S_IDLE_TIMEOUT,
         s_open_timeout: Pubnub::Constants::DEFAULT_S_OPEN_TIMEOUT,
         s_read_timeout: Pubnub::Constants::DEFAULT_S_READ_TIMEOUT,
-        s_idle_timeout: Pubnub::Constants::DEFAULT_S_IDLE_TIMEOUT,
+        s_send_timeout: Pubnub::Constants::DEFAULT_S_SEND_TIMEOUT,
         reconnect_attempts: Pubnub::Constants::DEFAULT_RECONNECT_ATTEMPTS,
         reconnect_interval: Pubnub::Constants::DEFAULT_RECONNECT_INTERVAL,
         region: Pubnub::Constants::DEFAULT_REGION,

--- a/lib/pubnub/constants.rb
+++ b/lib/pubnub/constants.rb
@@ -5,9 +5,11 @@ module Pubnub
     # Config constants
     DEFAULT_READ_TIMEOUT               = 10
     DEFAULT_OPEN_TIMEOUT               = 10
+    DEFAULT_SEND_TIMEOUT               = 10
     DEFAULT_IDLE_TIMEOUT               = 10
     DEFAULT_S_READ_TIMEOUT             = 310
     DEFAULT_S_OPEN_TIMEOUT             = 310
+    DEFAULT_S_SEND_TIMEOUT             = 310
     DEFAULT_S_IDLE_TIMEOUT             = 310
     DEFAULT_H_READ_TIMEOUT             = 10
     DEFAULT_H_OPEN_TIMEOUT             = 10


### PR DESCRIPTION
We'd like to have better control over the timeout configuration since PubNub is generally very fast and once it starts getting into the 1+ second we'd like to shut it off (though our Circuit breaker setup) so we don't block our message queues.