### PR TITLE
Proposal: option to not boot Celluloid

### DIFF
--- a/lib/pubnub.rb
+++ b/lib/pubnub.rb
@@ -5,8 +5,6 @@ require 'open-uri'
 require 'openssl'
 require 'celluloid/current'
 
-Celluloid.boot
-
 require 'timers'
 require 'httpclient'
 require 'logger'

--- a/lib/pubnub/client.rb
+++ b/lib/pubnub/client.rb
@@ -167,6 +167,8 @@ module Pubnub
       Pubnub.logger.debug('Pubnub::Client') do
         "Created new Pubnub::Client instance. Version: #{Pubnub::VERSION}"
       end
+
+      Celluloid.boot if @env[:boot_celluloid] && !Celluloid.running?
     end
 
     def add_listener(options)

--- a/lib/pubnub/client.rb
+++ b/lib/pubnub/client.rb
@@ -378,7 +378,7 @@ module Pubnub
     def assign_defaults
       @env[:origin] = @env[:origins_pool].first if @env[:origins_pool]
       default_values.each do |k, v|
-        @env[k] = v unless @env[k]
+        @env[k] = v unless @env.key?(k)
       end
       @env[:timetoken] = 0
       @env[:sequence_number_for_publish] = 0

--- a/lib/pubnub/client.rb
+++ b/lib/pubnub/client.rb
@@ -168,7 +168,7 @@ module Pubnub
         "Created new Pubnub::Client instance. Version: #{Pubnub::VERSION}"
       end
 
-      Celluloid.boot if @env[:boot_celluloid] && !Celluloid.running?
+      Celluloid.boot if @env[:boot_celluloid] && celluloid_not_running?
     end
 
     def add_listener(options)
@@ -386,6 +386,12 @@ module Pubnub
         symbolized_options.merge!(k.to_sym => options[k])
       end
       symbolized_options
+    end
+
+    def celluloid_not_running?
+      !Celluloid.running?
+    rescue Celluloid::Error
+      true
     end
   end
 end

--- a/lib/pubnub/client.rb
+++ b/lib/pubnub/client.rb
@@ -163,12 +163,12 @@ module Pubnub
       clean_env
       prepare_env
       validate! @env
-      @telemetry = Telemetry.new
       Pubnub.logger.debug('Pubnub::Client') do
         "Created new Pubnub::Client instance. Version: #{Pubnub::VERSION}"
       end
 
       Celluloid.boot if @env[:boot_celluloid] && celluloid_not_running?
+      @telemetry = Telemetry.new unless celluloid_not_running?
     end
 
     def add_listener(options)
@@ -305,10 +305,14 @@ module Pubnub
     end
 
     def record_telemetry(telemetry_type, time_start, time_end)
+      return unless @telemetry
+
       @telemetry.record_request(telemetry_type, time_start, time_end)
     end
 
     def telemetry_for(event)
+      return nil unless @telemetry
+
       @telemetry.fetch_average(event)
     end
 

--- a/lib/pubnub/client.rb
+++ b/lib/pubnub/client.rb
@@ -328,15 +328,19 @@ module Pubnub
 
       case event_type
       when :subscribe_event
-        hc.receive_timeout = 310
+        hc.connect_timeout = @env[:s_open_timeout]
+        hc.send_timeout = @env[:s_send_timeout]
+        hc.receive_timeout = @env[:s_read_timeout]
         unless @env[:disable_keepalive] || @env[:disable_subscribe_keepalive]
-          hc.keep_alive_timeout = 310
+          hc.keep_alive_timeout = @env[:idle_timeout]
           hc.tcp_keepalive = true
         end
       when :single_event
-        hc.receive_timeout = 5
+        hc.connect_timeout = @env[:open_timeout]
+        hc.send_timeout = @env[:send_timeout]
+        hc.receive_timeout = @env[:read_timeout]
         unless @env[:disable_keepalive] || @env[:disable_non_subscribe_keepalive]
-          hc.keep_alive_timeout = 310
+          hc.keep_alive_timeout = @env[:idle_timeout]
           hc.tcp_keepalive = true
         end
       end

--- a/lib/pubnub/client/helpers.rb
+++ b/lib/pubnub/client/helpers.rb
@@ -34,7 +34,7 @@ module Pubnub
       end
 
       def clean_env
-        @env.delete_if { |_, v| v.blank? } # nillify if blank
+        @env.delete_if { |_, v| v.nil? || v.is_a?(String) && v.blank? } # nillify if blank
       end
     end
   end

--- a/lib/pubnub/configuration.rb
+++ b/lib/pubnub/configuration.rb
@@ -5,13 +5,16 @@ module Pubnub
     private
 
     def default_values
-      { origin: Pubnub::Constants::DEFAULT_ORIGIN,
+      {
+        origin: Pubnub::Constants::DEFAULT_ORIGIN,
+        idle_timeout: Pubnub::Constants::DEFAULT_IDLE_TIMEOUT,
         open_timeout: Pubnub::Constants::DEFAULT_OPEN_TIMEOUT,
         read_timeout: Pubnub::Constants::DEFAULT_READ_TIMEOUT,
-        idle_timeout: Pubnub::Constants::DEFAULT_IDLE_TIMEOUT,
+        send_timeout: Pubnub::Constants::DEFAULT_SEND_TIMEOUT,
+        s_idle_timeout: Pubnub::Constants::DEFAULT_S_IDLE_TIMEOUT,
         s_open_timeout: Pubnub::Constants::DEFAULT_S_OPEN_TIMEOUT,
         s_read_timeout: Pubnub::Constants::DEFAULT_S_READ_TIMEOUT,
-        s_idle_timeout: Pubnub::Constants::DEFAULT_S_IDLE_TIMEOUT,
+        s_send_timeout: Pubnub::Constants::DEFAULT_S_SEND_TIMEOUT,
         reconnect_attempts: Pubnub::Constants::DEFAULT_RECONNECT_ATTEMPTS,
         reconnect_interval: Pubnub::Constants::DEFAULT_RECONNECT_INTERVAL,
         region: Pubnub::Constants::DEFAULT_REGION,

--- a/lib/pubnub/configuration.rb
+++ b/lib/pubnub/configuration.rb
@@ -6,20 +6,21 @@ module Pubnub
 
     def default_values
       {
-        origin: Pubnub::Constants::DEFAULT_ORIGIN,
+        boot_celluloid: true,
         idle_timeout: Pubnub::Constants::DEFAULT_IDLE_TIMEOUT,
         open_timeout: Pubnub::Constants::DEFAULT_OPEN_TIMEOUT,
+        origin: Pubnub::Constants::DEFAULT_ORIGIN,
         read_timeout: Pubnub::Constants::DEFAULT_READ_TIMEOUT,
-        send_timeout: Pubnub::Constants::DEFAULT_SEND_TIMEOUT,
+        reconnect_attempts: Pubnub::Constants::DEFAULT_RECONNECT_ATTEMPTS,
+        reconnect_interval: Pubnub::Constants::DEFAULT_RECONNECT_INTERVAL,
+        region: Pubnub::Constants::DEFAULT_REGION,
+        request_message_count_threshold: Pubnub::Constants::REQUEST_MESSAGE_COUNT_THRESHOLD,
         s_idle_timeout: Pubnub::Constants::DEFAULT_S_IDLE_TIMEOUT,
         s_open_timeout: Pubnub::Constants::DEFAULT_S_OPEN_TIMEOUT,
         s_read_timeout: Pubnub::Constants::DEFAULT_S_READ_TIMEOUT,
         s_send_timeout: Pubnub::Constants::DEFAULT_S_SEND_TIMEOUT,
-        reconnect_attempts: Pubnub::Constants::DEFAULT_RECONNECT_ATTEMPTS,
-        reconnect_interval: Pubnub::Constants::DEFAULT_RECONNECT_INTERVAL,
-        region: Pubnub::Constants::DEFAULT_REGION,
+        send_timeout: Pubnub::Constants::DEFAULT_SEND_TIMEOUT,
         ssl: Pubnub::Constants::DEFAULT_SSL,
-        request_message_count_threshold: Pubnub::Constants::REQUEST_MESSAGE_COUNT_THRESHOLD
       }
     end
   end

--- a/lib/pubnub/constants.rb
+++ b/lib/pubnub/constants.rb
@@ -5,9 +5,11 @@ module Pubnub
     # Config constants
     DEFAULT_READ_TIMEOUT               = 10
     DEFAULT_OPEN_TIMEOUT               = 10
+    DEFAULT_SEND_TIMEOUT               = 10
     DEFAULT_IDLE_TIMEOUT               = 10
     DEFAULT_S_READ_TIMEOUT             = 310
     DEFAULT_S_OPEN_TIMEOUT             = 310
+    DEFAULT_S_SEND_TIMEOUT             = 310
     DEFAULT_S_IDLE_TIMEOUT             = 310
     DEFAULT_H_READ_TIMEOUT             = 10
     DEFAULT_H_OPEN_TIMEOUT             = 10


### PR DESCRIPTION
Hi again!

We're exclusively using the PubNub gem in Sidekiq so we can perform retries on errors and therefore we don't need the async parts of the PubNub (we run everything with `http_sync: true`). This means we don't really need Celluloid sticking around and we'd like to disable it.

This is my proposal for allowing users to disable Celluloid at their own risk.

Specs will definitely fail but if you're happy this I'll go ahead and add specs around this.