### PR TITLE
Use __dir__ to assert lib root

### DIFF
--- a/lib/pubnub/client.rb
+++ b/lib/pubnub/client.rb
@@ -50,7 +50,7 @@ require 'pubnub/validators/delete'
 require 'pubnub/validators/message_counts'
 require 'pubnub/validators/push'
 
-Dir[File.join(Dir.pwd, 'lib', 'pubnub', 'events', '*.rb')].each do |file|
+Dir[File.join(File.dirname(__dir__), 'pubnub', 'events', '*.rb')].each do |file|
   require file
 end
 


### PR DESCRIPTION
Fix a bug with asserting root directory