### PR TITLE
Catch OpenSSL errors on PAM

### DIFF
--- a/lib/pubnub/pam.rb
+++ b/lib/pubnub/pam.rb
@@ -80,6 +80,9 @@ module Pubnub
       when HTTPClient::TimeoutError
         error_category = Pubnub::Constants::STATUS_TIMEOUT
         code = 408
+      when OpenSSL::SSL::SSLError
+        error_category = Pubnub::Constants::SSL_ERROR
+        code = nil
       else
         error_category = Pubnub::Constants::STATUS_ERROR
         code = req_res_objects[:response].code


### PR DESCRIPTION
This change ensures that `OpenSSL::SSL::SSLError` errors are handled for `Pubnub::PAM#error_envelope` the same way as they are for `Pubnub::Event#error_envelope`. Prior to this change, in the event of an SSL error, we would see a `NoMethodError` bubble up from our call to `grant`.

```
NoMethodError: undefined method `code' for #<OpenSSL::SSL::SSLError:0x000055d2d4cbf780>
…undler/gems/pubnub-ruby-130e129d183b/lib/pubnub/pam.rb:   96:in `error_envelope'
…pubnub-ruby-130e129d183b/lib/pubnub/event/formatter.rb:    9:in `format_envelopes'
…dler/gems/pubnub-ruby-130e129d183b/lib/pubnub/event.rb:  171:in `handle'
…dler/gems/pubnub-ruby-130e129d183b/lib/pubnub/event.rb:   41:in `fire'
```

Below is the corresponding code from `Pubnub::Event`:
https://github.com/pubnub/ruby/blob/30ddc64745aaaab629c4e92008bf7d1d5ea53015/lib/pubnub/event.rb#L213-L227
