### PR TITLE
Exclude fixtures and specs from the exported gem

### DIFF
--- a/pubnub.gemspec
+++ b/pubnub.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pubnub/version'
@@ -12,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'http://github.com/pubnub/ruby'
   spec.license = 'MIT'
 
-  spec.files = `git ls-files -z`.split("\x0")
+  spec.files = `git ls-files -z`.split("\x0").grep_v(/^(fixtures|spec)/)
   spec.executables = spec.files.grep(%r{^bin\/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)\/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
# Summary
Leave out some unnecessary files from the built gem to reduce the installed footprint on disk.

# Impetus
I work at a company with a large rails monolith, and as part of our CI workflow the built workspace gets zipped up and passed from container to container, then decompressed again. We've lately started hitting intermittent memory issues during that decompression stage, because the workspace is crossing a size threshold - digging into why that is so, we see that a few particular gems are eating up *drastically* more disk space than the others. In a few cases it's clear why they would (nokogiri, sassc, etc). But this gem was the largest, and appears to be mostly made up of VCR cassette fixture files, which seemed like an easy fix.

(For what it's worth, this probably affects people using *heroku* much more, as they strictly limit slug size.)

# Implementation
* In the gemspec, specifically exclude all of the paths starting with `fixtures` or `specs`.
  - dropping `fixtures/*` took the installed footprint from 55MB to 13MB,
  - dropping `specs/*` as well gets us down to 1.3M, the same ballpark as the majority of other pure-ruby gems.
  - This also takes the *compiled* gem size from 1.4MB to about 240KB, which seems like a meaningful gain.
  - There are various other files that could be dropped, but I didn't think it was worth adding complexity to the gemspec for them, as they're neither numerous nor large.
