### PR TITLE
gemspec: Drop unused directives

### DIFF
--- a/pubnub.gemspec
+++ b/pubnub.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
 
   spec.files = `git ls-files -z`.split("\x0").grep_v(/^(test|spec|fixtures)/)
-  spec.executables = spec.files.grep(%r{^bin\/}) { |f| File.basename(f) }
-  spec.test_files = spec.files.grep(%r{^(test|spec|features)\/})
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4'
 


### PR DESCRIPTION
This PR removes two unused gemspec directives:

- test_files is unused in RubyGems
- this gem exposes 0 executables