### PR TITLE
Remove stray space in string interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
 ```ruby
 callback = Pubnub::SubscribeCallback.new(
     message: ->(envelope) {
-        puts "MESSAGE: # {puts envelope.result[:data][:message]['msg']}"
+        puts "MESSAGE: #{puts envelope.result[:data][:message]['msg']}"
     },
     presence: ->(envelope) {
         puts "PRESENCE: #{envelope.result[:data]}"


### PR DESCRIPTION
The example had a space between the hash and opening brace characters, rendering the attempted output ineffective. This is also present in the [ruby SDK documentation](https://www.pubnub.com/docs/sdks/ruby), which should be updated as well.